### PR TITLE
tomcat日志文件格式多了个点

### DIFF
--- a/include/tomcat-6.sh
+++ b/include/tomcat-6.sh
@@ -91,7 +91,7 @@ EOF
 <Host name="localhost" appBase="${wwwroot_dir}/default" unpackWARs="true" autoDeploy="true">
   <Context path="" docBase="${wwwroot_dir}/default" debug="0" reloadable="false" crossContext="true"/>
   <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
-    prefix="localhost_access_log." suffix=".txt" pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+    prefix="localhost_access_log" suffix=".txt" pattern="%h %l %u %t &quot;%r&quot; %s %b" />
 </Host>
 EOF
     # logrotate tomcat catalina.out

--- a/include/tomcat-7.sh
+++ b/include/tomcat-7.sh
@@ -91,7 +91,7 @@ EOF
 <Host name="localhost" appBase="${wwwroot_dir}/default" unpackWARs="true" autoDeploy="true">
   <Context path="" docBase="${wwwroot_dir}/default" debug="0" reloadable="false" crossContext="true"/>
   <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
-    prefix="localhost_access_log." suffix=".txt" pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+    prefix="localhost_access_log" suffix=".txt" pattern="%h %l %u %t &quot;%r&quot; %s %b" />
 </Host>
 EOF
     # logrotate tomcat catalina.out

--- a/include/tomcat-8.sh
+++ b/include/tomcat-8.sh
@@ -91,7 +91,7 @@ EOF
 <Host name="localhost" appBase="${wwwroot_dir}/default" unpackWARs="true" autoDeploy="true">
   <Context path="" docBase="${wwwroot_dir}/default" debug="0" reloadable="false" crossContext="true"/>
   <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
-    prefix="localhost_access_log." suffix=".txt" pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+    prefix="localhost_access_log" suffix=".txt" pattern="%h %l %u %t &quot;%r&quot; %s %b" />
 </Host>
 EOF
     # logrotate tomcat catalina.out


### PR DESCRIPTION
localhost_access_log. -> localhost_access_log 参考官方文档。

```xml
<!-- Access log processes all example.
       Documentation at: /docs/config/valve.html
       Note: The pattern used is equivalent to using pattern="common" -->
       <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
               prefix="localhost_access_log" suffix=".txt"
               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
```