### PR TITLE
openssl: Openssl path bug fixes

### DIFF
--- a/include/openssl.sh
+++ b/include/openssl.sh
@@ -17,6 +17,9 @@ Install_openSSL102() {
     make clean
     ./config --prefix=${openssl_install_dir} -fPIC shared zlib-dynamic
     make -j ${THREAD} && make install
+    [ -z "`grep ^'export PATH=' /etc/profile`" ] && echo "export PATH=${openssl_install_dir}/bin:\$PATH" >> /etc/profile
+    [ -n "`grep ^'export PATH=' /etc/profile`" -a -z "`grep ${openssl_install_dir} /etc/profile`" ] && sed -i "s@^export PATH=\(.*\)@export PATH=${openssl_install_dir}/bin:\1@" /etc/profile
+    . /etc/profile
     popd
     if [ -f "${openssl_install_dir}/lib/libcrypto.a" ]; then
       echo "${CSUCCESS}openssl-1.0.2 module installed successfully! ${CEND}"


### PR DESCRIPTION
Fix openssl bug.

`openssl: /usr/local/openssl/lib/libssl.so.1.0.0: no version information available (required by openssl)`
`openssl: /usr/local/openssl/lib/libssl.so.1.0.0: no version information available (required by openssl)`
`openssl: /usr/local/openssl/lib/libcrypto.so.1.0.0: no version information available (required by openssl)`
`openssl: /usr/local/openssl/lib/libcrypto.so.1.0.0: no version information available (required by openssl)`
`openssl: /usr/local/openssl/lib/libcrypto.so.1.0.0: no version information available (required by openssl)`