### PR TITLE
Fix only install php cause missing openssl

### DIFF
--- a/include/check_download.sh
+++ b/include/check_download.sh
@@ -11,11 +11,13 @@ checkDownload() {
   mirrorLink=http://mirrors.linuxeye.com/oneinstack/src
   pushd ${oneinstack_dir}/src
 
+  # General system utils
+  echo "Download openSSL..."
+  src_url=https://www.openssl.org/source/openssl-${openssl_version}.tar.gz && Download_src
+  src_url=http://curl.haxx.se/ca/cacert.pem && Download_src
+
   # Web
   if [ "${Web_yn}" == 'y' ]; then
-    echo "Download openSSL..."
-    src_url=https://www.openssl.org/source/openssl-${openssl_version}.tar.gz && Download_src
-    src_url=http://curl.haxx.se/ca/cacert.pem && Download_src
     case "${Nginx_version}" in
       1)
         echo "Download nginx..."

--- a/include/check_sw.sh
+++ b/include/check_sw.sh
@@ -21,7 +21,7 @@ installDepsDebian() {
   grep security /etc/apt/sources.list > /tmp/security.sources.list
   apt-get -y upgrade -o Dir::Etc::SourceList=/tmp/security.sources.list
 
-  apt-get autoremove
+  apt-get -y autoremove
 
   # Install needed packages
   case "${Debian_version}" in


### PR DESCRIPTION
Beacuse not only nginx required openssl, but php also needs it.