### PR TITLE
update default_authentication_plugin

### DIFF
--- a/include/mysql-8.0.sh
+++ b/include/mysql-8.0.sh
@@ -90,6 +90,8 @@ server-id = 1
 init-connect = 'SET NAMES utf8mb4'
 character-set-server = utf8mb4
 
+default_authentication_plugin=mysql_native_password
+
 skip-name-resolve
 #skip-networking
 back_log = 300


### PR DESCRIPTION
In MySQL 8.0, caching_sha2_password is the default authentication plugin rather than mysql_native_password.When it is actually used, it is found that it is not possible to login to MySQL without using encryption. For example, phpMyAdmin.